### PR TITLE
Add KL University Domain (klu.ac.in)

### DIFF
--- a/lib/domains/in/edu/klu.txt
+++ b/lib/domains/in/edu/klu.txt
@@ -1,0 +1,2 @@
+Kalasalingam Academy of Research and Education
+Kalasalingam Academy of Research and Education


### PR DESCRIPTION
I’ve added the main domain klu.ac.in for KL University. The file contains the official name of the institution and an alternative name

Kalasalingam Academy of Research and Education
Kalasalingam Academy of Research and Education